### PR TITLE
Add "yarn lint" rule, using ESLint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@folio/eslint-config-stripes",
+  "parser": "babel-eslint"
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,15 @@
   "version": "1.0.0",
   "description": "Ship loaned items to borrowing library",
   "main": "src/index.js",
+  "scripts": {
+    "lint": "eslint ."
+  },
   "license": "Apache-2.0",
+  "devDependencies": {
+    "@folio/eslint-config-stripes": "^4.2.100042",
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.5.0"
+  },
   "stripes": {
     "actsAs": ["app"],
     "displayName": "ui-shipping.meta.title",


### PR DESCRIPTION
These configuration changes mean that (after re-running `yarn install`) you will be able to run `yarn lint` to style-check the module according to standard Stripes guidelines.

(Do not be too discouraged by the voluminous output, "310 problems (258 errors, 52 warnings)" — most of them will be trivial to fix. If my experience is any guide, in among the pithering and pedantry, you'll find a few places where it's spotted genuine flaws in your code.)